### PR TITLE
Relevant btns

### DIFF
--- a/imports/plugins/custom/admin/client/components/overview/overviewDashboard.js
+++ b/imports/plugins/custom/admin/client/components/overview/overviewDashboard.js
@@ -146,13 +146,15 @@ class AdminOverviewDashboard extends Component {
 
           {this.state.openList ?
             <ProductSummaryList
-            searchQuery={this.state.searchQuery}
-            filterOpen={this.state.filterOpen}
+              searchQuery={this.state.searchQuery}
+              filterOpen={this.state.filterOpen}
+              setSideViewContent={this.setSideView}
+              closeSideView={this.handleSideViewClose}
             />
             :
             <SupplierSummaryList
-            searchQuery={this.state.searchQuery}
-            setSideViewContent={this.setSideView}
+              searchQuery={this.state.searchQuery}
+              setSideViewContent={this.setSideView}
             />
           }
         </div>

--- a/imports/plugins/custom/admin/client/components/overview/productSummaryList.js
+++ b/imports/plugins/custom/admin/client/components/overview/productSummaryList.js
@@ -41,7 +41,7 @@ class ProductSummaryList extends Component {
         Header: "Avoinna",
         id: "openQuantity",
         Cell: info => (
-          <div className={"open-total" + (info.original.openQuantity ? "" : "-zero")}> 
+          <div className={info.original.isVariant ? "open-total" + (info.original.openQuantity ? "" : "-zero"): "contract-info"}> 
             {info.original.openQuantity} 
           </div>
         ),
@@ -49,19 +49,23 @@ class ProductSummaryList extends Component {
         Header: "Tuotannossa",
         id: "production",
         Cell: info => (
-          <div className="contract-total"> {info.original.production} </div>
+          <div className={info.original.isVariant ? (info.original.production > 0 ? "contract-total": "open-total-zero") : "contract-info"}> 
+            {info.original.production}
+          </div>
         ),
       }, {
         Header: "Lähetyksiä",
         id: "delivery",
         Cell: info => (
-          <div className="contract-total"> {info.original.delivery} </div>
+          <div className={info.original.isVariant ? (info.original.received > 0 ? "contract-total": "open-total-zero") : "contract-info"}> 
+            {info.original.delivery} 
+          </div>
         ),
       }, {
         Header: "Vastaanotettu",
         id: "received",
         Cell: info => (
-          <div className="contract-total"> {info.original.received} </div>
+          <div className="contract-info"> {info.original.received} </div>
         ),
       }
     ];

--- a/imports/plugins/custom/admin/client/components/overview/productSummaryList.js
+++ b/imports/plugins/custom/admin/client/components/overview/productSummaryList.js
@@ -17,6 +17,9 @@ import { ContractItems, OpenSimpleTotals, OpenVariantOptionTotals,
 import { getProductVariants, getVariantOptions, 
          getProductSummary, getVariantSummary } from '../../helpers/productOverview';
 
+import ContractDialog from '../../../../supplier/client/components/overview/contractDialog';         
+import DeliveryDialog from '../../../../supplier/client/components/overview/deliveryDialog';         
+
 class ProductSummaryList extends Component {
   constructor(props) {
     super(props);
@@ -41,7 +44,21 @@ class ProductSummaryList extends Component {
         Header: "Avoinna",
         id: "openQuantity",
         Cell: info => (
-          <div className={info.original.isVariant ? "open-total" + (info.original.openQuantity ? "" : "-zero"): "contract-info"}> 
+          <div 
+            className={info.original.isVariant ? "open-total" + (info.original.openQuantity ? "" : "-zero"): "contract-info"}
+            onClick={() => {(info.original.isVariant && info.original.openQuantity > 0) ? 
+              this.props.setSideViewContent(
+                <ContractDialog
+                  productId={info.original.productId}
+                  productName={info.original.simpleTitle}
+                  variantName={info.original.title}
+                  openQuantity={info.original.openQuantity}
+                  closeSideView={this.props.closeSideView}
+                />
+              ) : 
+              {}
+            }}
+          > 
             {info.original.openQuantity} 
           </div>
         ),
@@ -49,12 +66,26 @@ class ProductSummaryList extends Component {
         Header: "Tuotannossa",
         id: "production",
         Cell: info => (
-          <div className={info.original.isVariant ? (info.original.production > 0 ? "contract-total": "open-total-zero") : "contract-info"}> 
+          <div 
+            className={info.original.isVariant ? (info.original.production > 0 ? "contract-total": "open-total-zero") : "contract-info"}
+            onClick={() => {(info.original.isVariant && info.original.production > 0) ? 
+              this.props.setSideViewContent(
+                <DeliveryDialog
+                  productId={info.original.productId}
+                  productName={info.original.simpleTitle}
+                  variantName={info.original.title}
+                  contractQuantity={info.original.production}
+                  closeSideView={this.props.closeSideView}
+                />
+              ) : 
+              {}
+            }}
+          > 
             {info.original.production}
           </div>
         ),
       }, {
-        Header: "Lähetyksiä",
+        Header: "Lähetetty",
         id: "delivery",
         Cell: info => (
           <div className={info.original.isVariant ? (info.original.received > 0 ? "contract-total": "open-total-zero") : "contract-info"}> 
@@ -172,6 +203,10 @@ class ProductSummaryList extends Component {
 
 ProductSummaryList.propTypes = {
   productSummaries: PropTypes.arrayOf(PropTypes.object),
+  searchQuery: PropTypes.string,
+  filterOpen: PropTypes.bool,
+  setSideViewContent: PropTypes.func,
+  closeSideView: PropTypes.func
 }
 
 function composer(props, onData) {

--- a/imports/plugins/custom/admin/client/helpers/productOverview.js
+++ b/imports/plugins/custom/admin/client/helpers/productOverview.js
@@ -44,8 +44,10 @@ export function getVariantSummary(variant, option = false) {
     ), {
       variantTitle: variant.title,
       optionTitle: option.optionTitle,
+      productId: productId,
       title: title,
       isOption: option ? true : false,
+      isVariant: true,
       openQuantity: 0,
       production: 0,
       delivery: 0,

--- a/imports/plugins/custom/supplier/client/components/overview/contractDialog.js
+++ b/imports/plugins/custom/supplier/client/components/overview/contractDialog.js
@@ -33,7 +33,6 @@ class ContractDialog extends Component {
     if (cancelled || this.state.supplyQuantity == 0 || this.props.openQuantity <= 0) {
       this.props.closeSideView();
     } else {
-      console.log("Kutsutaan metodia: " + this.props.productId + " / " + parseInt(this.state.supplyQuantity) + " kpl")
       const contractId = Meteor.call("supplyContracts/create", this.props.productId, parseInt(this.state.supplyQuantity));
       this.showAlert(
         "Toimitussopimus tehty (" + 

--- a/imports/plugins/custom/supplier/client/components/overview/productOverviewList.js
+++ b/imports/plugins/custom/supplier/client/components/overview/productOverviewList.js
@@ -64,8 +64,8 @@ class ProductOverviewList extends Component {
         id: "production",
         Cell: info => (
           <div 
-            className="contract-total"
-            onClick={() => this.props.setSideViewContent(
+            className={info.original.isVariant ? "contract-total" : "contract-info"}
+            onClick={() => {info.original.isVariant ? this.props.setSideViewContent(
               <DeliveryDialog
                 productId={info.original.productId}
                 productName={info.original.simpleTitle}
@@ -73,7 +73,7 @@ class ProductOverviewList extends Component {
                 contractQuantity={info.original.production}
                 closeSideView={this.props.closeSideView}
               />
-            )}
+            ) : {}}}
           >
             {info.original.production}
           </div>
@@ -82,13 +82,13 @@ class ProductOverviewList extends Component {
         Header: "Lähetetty",
         id: "delivery",
         Cell: info => (
-          <div className="contract-total"> {info.original.delivery} </div>
+          <div className="contract-info"> {info.original.delivery} </div>
         ),
       }, {
         Header: "Vastaanotettu",
         id: "received",
         Cell: info => (
-          <div className="contract-total"> {info.original.received} </div>
+          <div className="contract-info"> {info.original.received} </div>
         ),
       }
     ];

--- a/imports/plugins/custom/supplier/client/components/overview/productOverviewList.js
+++ b/imports/plugins/custom/supplier/client/components/overview/productOverviewList.js
@@ -45,16 +45,19 @@ class ProductOverviewList extends Component {
         id: "openQuantity",
         Cell: info => (
           <div 
-            className={"open-total" + (info.original.openQuantity ? "" : "-zero")}
-            onClick={() => this.props.setSideViewContent(
-              <ContractDialog
-                productId={info.original.productId}
-                productName={info.original.simpleTitle}
-                variantName={info.original.title}
-                openQuantity={info.original.openQuantity}
-                closeSideView={this.props.closeSideView}
-              />
-            )}
+            className={info.original.isVariant ? "open-total" + (info.original.openQuantity ? "" : "-zero") : "contract-info"}
+            onClick={() => {(info.original.isVariant && info.original.openQuantity > 0) ? 
+              this.props.setSideViewContent(
+                <ContractDialog
+                  productId={info.original.productId}
+                  productName={info.original.simpleTitle}
+                  variantName={info.original.title}
+                  openQuantity={info.original.openQuantity}
+                  closeSideView={this.props.closeSideView}
+                />
+              ) : 
+              {}
+            }}
           >
             {info.original.openQuantity} 
           </div>
@@ -64,16 +67,19 @@ class ProductOverviewList extends Component {
         id: "production",
         Cell: info => (
           <div 
-            className={info.original.isVariant ? "contract-total" : "contract-info"}
-            onClick={() => {info.original.isVariant ? this.props.setSideViewContent(
-              <DeliveryDialog
-                productId={info.original.productId}
-                productName={info.original.simpleTitle}
-                variantName={info.original.title}
-                contractQuantity={info.original.production}
-                closeSideView={this.props.closeSideView}
-              />
-            ) : {}}}
+            className={info.original.isVariant ? (info.original.production > 0 ? "contract-total" : "open-total-zero") : "contract-info"}
+            onClick={() => {(info.original.isVariant && info.original.production > 0) ? 
+              this.props.setSideViewContent(
+                <DeliveryDialog
+                  productId={info.original.productId}
+                  productName={info.original.simpleTitle}
+                  variantName={info.original.title}
+                  contractQuantity={info.original.production}
+                  closeSideView={this.props.closeSideView}
+                />
+              ) : 
+              {}
+            }}
           >
             {info.original.production}
           </div>

--- a/imports/plugins/custom/supplier/client/helpers/productOverview.js
+++ b/imports/plugins/custom/supplier/client/helpers/productOverview.js
@@ -47,6 +47,7 @@ export function getVariantSummary(variant, option = false) {
       productId: productId,
       title: title,
       isOption: option ? true : false,
+      isVariant: true,
       openQuantity: 0,
       production: 0,
       delivery: 0,


### PR DESCRIPTION
Supplier ja admin overview -näkymissä ainoastaan relevantit numerot on merkitty napeiksi.
Jos napin saldo on nolla, nappi on disabloitu ja harmaa.
Molemmissa overview -näkymissä variantin avoinna-nappi avaa sideview:iin toimitussopimuksen teko -dialogin ja tuotannossa-nappi toimitusilmoituksen teko -dialogin.

